### PR TITLE
Fix crash (and compiler warnings)

### DIFF
--- a/src/cpulimit.c
+++ b/src/cpulimit.c
@@ -43,7 +43,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
-#ifdef __APPLE__ || __FREEBSD__
+#if defined(__APPLE__) || defined(__FREEBSD__)
 #include <libgen.h>
 #endif
 

--- a/src/process_group.c
+++ b/src/process_group.c
@@ -25,6 +25,10 @@
 #include <sys/time.h>
 #include <signal.h>
 
+#if defined(__APPLE__) || defined(__FREEBSD__)
+#include <libgen.h>
+#endif
+
 #include <assert.h>
 
 #include "process_iterator.h"

--- a/tests/process_iterator_test.c
+++ b/tests/process_iterator_test.c
@@ -28,7 +28,7 @@
 #include <signal.h>
 #include <string.h>
 
-#ifdef __APPLE__ || __FREEBSD__
+#if defined(__APPLE__) || defined(__FREEBSD__)
 #include <libgen.h>
 #endif
 


### PR DESCRIPTION
Fix crash with "-e" option and remove compiler warnings
