### PR TITLE
Add Android support

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,22 @@
+#
+# Android.mk
+# Emiliano Firmino, 2015-11-17 19:28
+# minor changes by Andrea Scian
+#
+
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := cpulimit
+
+LOCAL_SRC_FILES := src/cpulimit.c \
+	src/list.c \
+	src/memrchr.c \
+	src/process_iterator.c \
+	src/process_group.c
+
+include $(BUILD_EXECUTABLE)
+
+# vim:ft=make
+#

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ On FreeBSD:
     $ gmake
     # cp src/cpulimit /usr/bin
 
+On Android (tested with NDK r11c, API >=22):
+
+    $ ndk-build  APP_BUILD_SCRIPT=$(pwd)/Android.mk NDK_PROJECT_PATH=$(pwd) APP_PLATFORM=android-22
+    # adb push src/cpulimit /data/cpulimit
+
 Run unit tests:
 
     $ ./tests/process_iterator_test

--- a/src/cpulimit.c
+++ b/src/cpulimit.c
@@ -43,7 +43,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
-#ifdef __APPLE__ || __FREEBSD__
+#if defined(__APPLE__) || defined(__FREEBSD__)
 #include <libgen.h>
 #endif
 

--- a/src/cpulimit.c
+++ b/src/cpulimit.c
@@ -38,7 +38,11 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/time.h>
+#ifdef ANDROID
+#include <linux/sysctl.h>
+#else
 #include <sys/sysctl.h>
+#endif
 #include <sys/resource.h>
 #include <sys/types.h>
 #include <sys/wait.h>

--- a/src/cpulimit.c
+++ b/src/cpulimit.c
@@ -2,7 +2,7 @@
  *
  * cpulimit - a CPU limiter for Linux
  *
- * Copyright (C) 2005-2012, by:  Angelo Marletta <angelo dot marletta at gmail dot com> 
+ * Copyright (C) 2005-2012, by:  Angelo Marletta <angelo dot marletta at gmail dot com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -139,7 +139,7 @@ static void increase_priority() {
 	int old_priority = getpriority(PRIO_PROCESS, 0);
 	int priority = old_priority;
 	while (setpriority(PRIO_PROCESS, 0, priority-1) == 0 && priority>MAX_PRIORITY) {
-		priority--;	
+		priority--;
 	}
 	if (priority != old_priority) {
 		if (verbose) printf("Priority changed to %d\n", priority);
@@ -200,7 +200,7 @@ void limit_process(pid_t pid, double limit, int include_children)
 	memset(&twork, 0, sizeof(struct timespec));
 	memset(&tsleep, 0, sizeof(struct timespec));
 	memset(&startwork, 0, sizeof(struct timeval));
-	memset(&endwork, 0, sizeof(struct timeval));	
+	memset(&endwork, 0, sizeof(struct timeval));
 	//last working time in microseconds
 	unsigned long workingtime = 0;
 	//generic list item
@@ -210,7 +210,7 @@ void limit_process(pid_t pid, double limit, int include_children)
 
 	//get a better priority
 	increase_priority();
-	
+
 	//build the family
 	init_process_group(&pgroup, pid, include_children);
 
@@ -226,7 +226,7 @@ void limit_process(pid_t pid, double limit, int include_children)
 			if (verbose) printf("No more processes.\n");
 			break;
 		}
-		
+
 		//total cpu actual usage (range 0-1)
 		//1 means that the processes are using 100% cpu
 		double pcpu = -1;
@@ -283,7 +283,7 @@ void limit_process(pid_t pid, double limit, int include_children)
 		nanosleep(&twork, NULL);
 		gettimeofday(&endwork, NULL);
 		workingtime = timediff(&endwork, &startwork);
-		
+
 		long delay = workingtime - twork.tv_nsec/1000;
 		if (c>0 && delay>10000) {
 			//delay is too much! signal to user?
@@ -413,7 +413,7 @@ int main(int argc, char **argv) {
 		print_usage(stderr, 1);
 		exit(1);
 	}
-	
+
 	if (exe_ok + pid_ok + command_mode > 1) {
 		fprintf(stderr,"Error: You must specify exactly one target process, either by name, pid, or command line\n");
 		print_usage(stderr, 1);
@@ -446,7 +446,7 @@ int main(int argc, char **argv) {
 			}
 			printf("'\n");
 		}
-		
+
 		int child = fork();
 		if (child < 0) {
 			exit(EXIT_FAILURE);
@@ -525,6 +525,6 @@ int main(int argc, char **argv) {
 		if (lazy) break;
 		sleep(2);
 	};
-	
+
 	exit(0);
 }

--- a/src/list.c
+++ b/src/list.c
@@ -2,7 +2,7 @@
  *
  * cpulimit - a CPU limiter for Linux
  *
- * Copyright (C) 2005-2012, by:  Angelo Marletta <angelo dot marletta at gmail dot com> 
+ * Copyright (C) 2005-2012, by:  Angelo Marletta <angelo dot marletta at gmail dot com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/list.h
+++ b/src/list.h
@@ -2,7 +2,7 @@
  *
  * cpulimit - a CPU limiter for Linux
  *
- * Copyright (C) 2005-2012, by:  Angelo Marletta <angelo dot marletta at gmail dot com> 
+ * Copyright (C) 2005-2012, by:  Angelo Marletta <angelo dot marletta at gmail dot com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/process_group.c
+++ b/src/process_group.c
@@ -2,7 +2,7 @@
  *
  * cpulimit - a CPU limiter for Linux
  *
- * Copyright (C) 2005-2012, by:  Angelo Marletta <angelo dot marletta at gmail dot com> 
+ * Copyright (C) 2005-2012, by:  Angelo Marletta <angelo dot marletta at gmail dot com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/process_iterator.c
+++ b/src/process_iterator.c
@@ -2,7 +2,7 @@
  *
  * cpulimit - a CPU limiter for Linux
  *
- * Copyright (C) 2005-2012, by:  Angelo Marletta <angelo dot marletta at gmail dot com> 
+ * Copyright (C) 2005-2012, by:  Angelo Marletta <angelo dot marletta at gmail dot com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/process_iterator_apple.c
+++ b/src/process_iterator_apple.c
@@ -2,7 +2,7 @@
  *
  * cpulimit - a CPU limiter for Linux
  *
- * Copyright (C) 2005-2012, by:  Angelo Marletta <angelo dot marletta at gmail dot com> 
+ * Copyright (C) 2005-2012, by:  Angelo Marletta <angelo dot marletta at gmail dot com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- * 
+ *
  * Author: Simon Sigurdhsson
  *
  */

--- a/src/process_iterator_freebsd.c
+++ b/src/process_iterator_freebsd.c
@@ -2,7 +2,7 @@
  *
  * cpulimit - a CPU limiter for Linux
  *
- * Copyright (C) 2005-2012, by:  Angelo Marletta <angelo dot marletta at gmail dot com> 
+ * Copyright (C) 2005-2012, by:  Angelo Marletta <angelo dot marletta at gmail dot com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/process_iterator_linux.c
+++ b/src/process_iterator_linux.c
@@ -2,7 +2,7 @@
  *
  * cpulimit - a CPU limiter for Linux
  *
- * Copyright (C) 2005-2012, by:  Angelo Marletta <angelo dot marletta at gmail dot com> 
+ * Copyright (C) 2005-2012, by:  Angelo Marletta <angelo dot marletta at gmail dot com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License


### PR DESCRIPTION
This is a simple change that allow cpulimit build on Android, using NDK.
Unfortunately, it works only with API >=22 because older API do not implement bsd_signal symbol. 

It can also be build inside AOSP with ease (I tested it with KK4.4.3, which is android-19 but didn't show the bsd_signal error)

The work was done by Emiliano Firmino (elmiliox@gmail.com) in its
project (https://github.com/Miliox/android-cpulimit), I just rework it a
little bit
