### PR TITLE
Fix compilation warning in GCC

### DIFF
--- a/src/cpulimit.c
+++ b/src/cpulimit.c
@@ -43,7 +43,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
-#ifdef __APPLE__ || __FREEBSD__
+#if defined(__APPLE__) || defined(__FREEBSD__)
 #include <libgen.h>
 #endif
 

--- a/tests/process_iterator_test.c
+++ b/tests/process_iterator_test.c
@@ -28,7 +28,7 @@
 #include <signal.h>
 #include <string.h>
 
-#ifdef __APPLE__ || __FREEBSD__
+#if defined(__APPLE__) || defined(__FREEBSD__)
 #include <libgen.h>
 #endif
 


### PR DESCRIPTION
Hi!
This fixes a compilation warning I got trying to compile this with GCC:

```
cpulimit.c:46:18: warning: extra tokens at end of #ifdef directive
```

According to https://stackoverflow.com/questions/2998864/how-to-add-a-or-condition-in-ifdef, the proper way to do OR together two #ifdef's is `#if defined(A) || defined(B)`, not `#ifdef A || B`.
Cheers!
