### PR TITLE
fix fd nullptr fgets coredump

### DIFF
--- a/src/process_iterator_linux.c
+++ b/src/process_iterator_linux.c
@@ -98,6 +98,7 @@ static int read_process_info(pid_t pid, struct process *p)
 	//read command line
 	sprintf(exefile,"/proc/%d/cmdline", p->pid);
 	fd = fopen(exefile, "r");
+	if (fd==NULL) return -1;
 	if (fgets(buffer, sizeof(buffer), fd)==NULL) {
 		fclose(fd);
 		return -1;


### PR DESCRIPTION
When process is exiting, /proc/${pid}/cmdline may be deleted before /proc/${pid}/stat. If /proc/${pid}/cmdline doesn't exist(but /proc/${pid}/stat exists), fopen returns nullptr, which makes fgets coredump.

