### PR TITLE
Fixes linux build with glibc-2.32.

### DIFF
--- a/src/cpulimit.c
+++ b/src/cpulimit.c
@@ -38,13 +38,13 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/time.h>
-#include <sys/sysctl.h>
 #include <sys/resource.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 
 #ifdef __APPLE__ || __FREEBSD__
 #include <libgen.h>
+#include <sys/sysctl.h>
 #endif
 
 #include "process_group.h"


### PR DESCRIPTION
* cpulimit.c: Guard inclusion of <sys/sysctl.h> which is needed only for
  __APPLE__ and is deprecated and unavailable starting with glibc-2.32.