### PR TITLE
Remove sys/sysctl.h and add missing libgen.h include

### DIFF
--- a/src/cpulimit.c
+++ b/src/cpulimit.c
@@ -38,7 +38,6 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/time.h>
-#include <sys/sysctl.h>
 #include <sys/resource.h>
 #include <sys/types.h>
 #include <sys/wait.h>

--- a/src/process_group.c
+++ b/src/process_group.c
@@ -24,6 +24,7 @@
 #include <limits.h>
 #include <sys/time.h>
 #include <signal.h>
+#include <libgen.h>
 
 #include <assert.h>
 


### PR DESCRIPTION
- sys/sysctl.h has been deprecated and should be removed
- Adds missing libgen.h include when calling basename()