### PR TITLE
Exit with code 124 if the process is interrupted eg with C-c.

### DIFF
--- a/src/cpulimit.c
+++ b/src/cpulimit.c
@@ -108,7 +108,7 @@ static void quit(int sig)
 	//fix ^C little problem
 	printf("\r");
 	fflush(stdout);
-	exit(0);
+	exit(124);
 }
 
 //return t1-t2 in microseconds (no overflow checks, so better watch out!)

--- a/src/process_group.c
+++ b/src/process_group.c
@@ -19,6 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+#include <libgen.h>
 #include <string.h>
 #include <stdlib.h>
 #include <limits.h>

--- a/tests/process_iterator_test.c
+++ b/tests/process_iterator_test.c
@@ -19,6 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+#include <libgen.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>


### PR DESCRIPTION
It's useful to be able to tell from the exit code whether a process was interrupted or not.